### PR TITLE
Css quickndirty

### DIFF
--- a/src/viz/templates/assets/css/main.css
+++ b/src/viz/templates/assets/css/main.css
@@ -3950,3 +3950,11 @@ input, select, textarea {
 			opacity: 1;
 			visibility: visible;
 		}
+
+
+/* Quick utils for placement */
+
+.center-block {
+	display: block !important;
+	margin: 0 auto !important;
+}

--- a/src/viz/templates/map_landing.html
+++ b/src/viz/templates/map_landing.html
@@ -190,7 +190,7 @@
 												</div>
 												<input type="hidden" id="country" name="country" required />
 												<div class="field full">
-													<button type="submit" class="my-button">See Local Summary</button>
+													<button type="submit" class="my-button center-block">See Local Summary</button>
 												</div>
 											</div>
 										</form>


### PR DESCRIPTION
As the subject implies, this is a quick and dirty (filthy, really) way to center the submit button on the map_landing page.

This pull request adds a new class to the end of the main.css file called .center-block. The props in this class have !important declaratives, which is definitely not something we should be throwing around, but again, see title. 

I've also added the new center-block rule to the element responsible for starting all of this, the submit button on map_landing. I did not remove the existing class of "my-button" because it is responsible for at least a little bit of styling. This class is also the reason we needed the !important declaration on the new class. For reference, .my-button can be found in the <style> tags at the top of the page. 

You can add .center-block to all sorts of other elements, should you wish to center them within their parent element, as well. 